### PR TITLE
More fixes based on review feedback

### DIFF
--- a/interfaces/builtin/desktop_launch.go
+++ b/interfaces/builtin/desktop_launch.go
@@ -46,7 +46,7 @@ const desktopLaunchConnectedPlugAppArmor = `
 
 dbus (send)
     bus=session
-    path=/io/snapcraft/Launcher
+    path=/io/snapcraft/PrivilegedDesktopLauncher
     interface=io.snapcraft.PrivilegedDesktopLauncher
     member=OpenDesktopEntry
     peer=(label=unconfined),

--- a/tests/main/interfaces-desktop-launch/task.yaml
+++ b/tests/main/interfaces-desktop-launch/task.yaml
@@ -11,6 +11,8 @@ prepare: |
         exit 0
     fi
     tests.session -u test prepare
+    tests.session -u test exec systemctl --user \
+      set-environment XDG_DATA_DIRS=/usr/share:/var/lib/snapd/desktop
 
 restore: |
     if ! tests.session has-session-systemd-and-dbus; then

--- a/tests/main/interfaces-desktop-launch/test-launcher/bin/launcher.sh
+++ b/tests/main/interfaces-desktop-launch/test-launcher/bin/launcher.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 exec dbus-send --session --print-reply \
-    --dest=io.snapcraft.Launcher /io/snapcraft/Launcher \
+    --dest=io.snapcraft.Launcher /io/snapcraft/PrivilegedDesktopLauncher \
     io.snapcraft.PrivilegedDesktopLauncher.OpenDesktopEntry \
     string:"$1"

--- a/usersession/userd/export_test.go
+++ b/usersession/userd/export_test.go
@@ -32,7 +32,9 @@ func MockSnapFromSender(f func(*dbus.Conn, dbus.Sender) (string, error)) func() 
 }
 
 var (
+	DesktopFileSearchPath          = desktopFileSearchPath
 	DesktopFileIDToFilename        = desktopFileIDToFilename
+	VerifyDesktopFileLocation      = verifyDesktopFileLocation
 	ParseExecCommand               = parseExecCommand
 	ReadExecCommandFromDesktopFile = readExecCommandFromDesktopFile
 )

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -62,7 +62,7 @@ func (s *PrivilegedDesktopLauncher) Interface() string {
 
 // BasePath returns the base path of the object
 func (s *PrivilegedDesktopLauncher) ObjectPath() dbus.ObjectPath {
-	return "/io/snapcraft/Launcher"
+	return "/io/snapcraft/PrivilegedDesktopLauncher"
 }
 
 // IntrospectionData gives the XML formatted introspection description

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -46,7 +46,7 @@ const privilegedLauncherIntrospectionXML = `
 </interface>
 <interface name='io.snapcraft.PrivilegedDesktopLauncher'>
 	<method name='OpenDesktopEntry'>
-		<arg type='s' name='desktopFileID' direction='in'/>
+		<arg type='s' name='desktop_file_id' direction='in'/>
 	</method>
 </interface>`
 
@@ -225,7 +225,7 @@ func verifyDesktopFileLocation(desktopFile string) error {
 		// /var/lib/snapd/desktop/applications and these desktop files are written by snapd and
 		// considered safe for userd to process. If other directories are added in the future,
 		// verifyDesktopFileLocation() and parseExecCommand() may need to be updated.
-		return fmt.Errorf("internal error: only launching snap applications from /var/lib/snapd/desktop/applications is supported")
+		return fmt.Errorf("internal error: only launching snap applications from %s is supported", dirs.SnapDesktopFilesDir)
 	}
 
 	return nil
@@ -298,7 +298,7 @@ func parseExecCommand(command string, icon string) ([]string, error) {
 			case "%i":
 				args = append(args, "--icon", icon)
 			default:
-				return nil, fmt.Errorf("cannot run %q", command)
+				return nil, fmt.Errorf("cannot run %q due to use of %q", command, arg)
 			}
 			continue
 		}

--- a/usersession/userd/privileged_desktop_launcher.go
+++ b/usersession/userd/privileged_desktop_launcher.go
@@ -241,11 +241,15 @@ func readExecCommandFromDesktopFile(desktopFile string) (exec string, icon strin
 	defer file.Close()
 	scanner := bufio.NewScanner(file)
 
-	inDesktopSection := false
+	var inDesktopSection, seenDesktopSection bool
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
 		if line == "[Desktop Entry]" {
+			if seenDesktopSection {
+				return "", "", fmt.Errorf("desktop file %q has multiple [Desktop Entry] sections", desktopFile)
+			}
+			seenDesktopSection = true
 			inDesktopSection = true
 		} else if strings.HasPrefix(line, "[Desktop Action ") {
 			// TODO: add support for desktop action sections

--- a/usersession/userd/privileged_desktop_launcher_internal_test.go
+++ b/usersession/userd/privileged_desktop_launcher_internal_test.go
@@ -565,6 +565,19 @@ func (s *privilegedDesktopLauncherInternalSuite) TestReadExecCommandFromDesktopF
 	c.Assert(err, ErrorMatches, `desktop file ".*" has an unsupported 'Exec' value: ""`)
 }
 
+func (s *privilegedDesktopLauncherInternalSuite) TestReadExecCOmmandFromDesktopFileMultipleDesktopEntrySections(c *C) {
+	desktopFile := filepath.Join(c.MkDir(), "test.desktop")
+	c.Assert(ioutil.WriteFile(desktopFile, []byte(`[Desktop Entry]
+Exec=foo
+
+[Desktop Entry]
+Exec=bar
+`), 0644), IsNil)
+
+	_, _, err := userd.ReadExecCommandFromDesktopFile(desktopFile)
+	c.Check(err, ErrorMatches, `desktop file ".*" has multiple \[Desktop Entry\] sections`)
+}
+
 func (s *privilegedDesktopLauncherInternalSuite) TestReadExecCommandFromDesktopFileWithNoFile(c *C) {
 	desktopFile := filepath.Join(c.MkDir(), "test.desktop")
 

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -46,6 +46,9 @@ func (s *privilegedDesktopLauncherSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.launcher = &userd.PrivilegedDesktopLauncher{}
 
+	c.Assert(os.MkdirAll(dirs.SnapDesktopFilesDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "/usr/share/applications"), 0755), IsNil)
+
 	var rawMircadeDesktop = `[Desktop Entry]
   X-SnapInstanceName=mircade
   Name=mircade
@@ -59,10 +62,11 @@ func (s *privilegedDesktopLauncherSuite) SetUpTest(c *C) {
 	desktopContent := strings.Replace(tmpMircadeDesktop, "/snap/bin/", dirs.SnapBinariesDir, -1)
 
 	deskTopFile := filepath.Join(dirs.SnapDesktopFilesDir, "mircade_mircade.desktop")
-	err := os.MkdirAll(filepath.Dir(deskTopFile), 0755)
-	c.Assert(err, IsNil)
-	err = ioutil.WriteFile(deskTopFile, []byte(desktopContent), 0644)
-	c.Assert(err, IsNil)
+	c.Assert(ioutil.WriteFile(deskTopFile, []byte(desktopContent), 0644), IsNil)
+
+	// Create a shadowed desktop file ID
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.GlobalRootDir, "/usr/share/applications/shadow-test.desktop"), []byte("[Desktop Entry]"), 0644), IsNil)
+	c.Assert(ioutil.WriteFile(filepath.Join(dirs.SnapDesktopFilesDir, "shadow-test.desktop"), []byte("[Desktop Entry]"), 0644), IsNil)
 
 	s.mockEnv("HOME", filepath.Join(dirs.GlobalRootDir, "/home/user"))
 	s.mockEnv("XDG_DATA_HOME", "")
@@ -99,7 +103,7 @@ func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntrySucceedsWithGoodDes
 	defer cmd.Restore()
 
 	err := s.launcher.OpenDesktopEntry("mircade_mircade.desktop", ":some-dbus-sender")
-	c.Assert(err, IsNil)
+	c.Check(err, IsNil)
 }
 
 func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsWithBadDesktopId(c *C) {
@@ -115,5 +119,13 @@ func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsWithBadExecuta
 	defer cmd.Restore()
 
 	err := s.launcher.OpenDesktopEntry("mircade_mircade.desktop", ":some-dbus-sender")
-	c.Assert(err, ErrorMatches, `cannot run ".*": exit status 1`)
+	c.Check(err, ErrorMatches, `cannot run ".*": exit status 1`)
+}
+
+func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntryFailsForNonSnap(c *C) {
+	cmd := testutil.MockCommand(c, "systemd-run", "false")
+	defer cmd.Restore()
+
+	err := s.launcher.OpenDesktopEntry("shadow-test.desktop", ":some-dbus-sender")
+	c.Check(err, ErrorMatches, `internal error: only launching snap applications from .* is supported`)
 }

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -84,6 +84,16 @@ func (s *privilegedDesktopLauncherSuite) mockEnv(key, value string) {
 	})
 }
 
+func (s *privilegedDesktopLauncherSuite) TestDesktopFileLookup(c *C) {
+	// We have more extensive tests for this API in
+	// privileged_desktop_launcher_internal_test.go: here we just
+	// test it without mocking the stat calls.
+	filename, err := userd.DesktopFileIDToFilename("mircade_mircade.desktop")
+	c.Assert(err, IsNil)
+	err = userd.VerifyDesktopFileLocation(filename)
+	c.Check(err, IsNil)
+}
+
 func (s *privilegedDesktopLauncherSuite) TestOpenDesktopEntrySucceedsWithGoodDesktopId(c *C) {
 	cmd := testutil.MockCommand(c, "systemd-run", "true")
 	defer cmd.Restore()


### PR DESCRIPTION
This set of fixes includes the following:

* Implement XDG Base Dir spec compliant desktop file ID lookup.  Now there are cases where `verifyDesktopFileLocation` could fail, so test those.
* Add a direct non-mocked test for `desktopFileIDToFilename` separate from the `OpenDesktopEntry` tests.
* Add a test showing that `OpenDesktopEntry` fails for a shadowed desktop file ID.
* Additional tests or cleanups based on Alex's and Ian's reviews that I'd missed previously.
* Change the object path the new API is exported on for more obvious separation from the existing Launcher API.